### PR TITLE
Include package name in package upgrade output

### DIFF
--- a/lib/commands/packages.js
+++ b/lib/commands/packages.js
@@ -15,7 +15,7 @@ const areWeOnline = async () => {
   }
 };
 
-const allPackages = async () => 
+const allPackages = async () =>
   (await exec(`pacman -Q`))
   .stdout
   .split("\n")
@@ -131,7 +131,7 @@ module.exports = async (defs) => {
       const from = allPackagesBeforeChanges[name];
       const to   = allPackagesAfterChanges[name];
 
-      console.log(`PACKAGE-UPGRADED: ${ from } -> ${ to }`);
+      console.log(`PACKAGE-UPGRADED: ${ name }(${ from }) -> ${ name }(${ to })`);
       changes.packages.updated[name] = { from, to };
     }
   }

--- a/lib/commands/packages.js
+++ b/lib/commands/packages.js
@@ -131,7 +131,7 @@ module.exports = async (defs) => {
       const from = allPackagesBeforeChanges[name];
       const to   = allPackagesAfterChanges[name];
 
-      console.log(`PACKAGE-UPGRADED: ${ name }(${ from }) -> ${ name }(${ to })`);
+      console.log(`PACKAGE-UPGRADED: ${ name }: ${ from } -> ${ to }`);
       changes.packages.updated[name] = { from, to };
     }
   }


### PR DESCRIPTION
Currently, the package upgrade console output only spits out the version change, but not the package that was upgrade. Added the package name to provide more context on the upgrade.